### PR TITLE
fix: ensure format list uses list styles

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -525,7 +525,7 @@ body {
   flex-shrink: 0;
 }
 
-.item .list { 
+.list {
   list-style: none; 
   margin: 0; 
   padding: 0; 


### PR DESCRIPTION
## Summary
- apply base list styling directly to `.list` so `<ul id="formatsList">` receives scrollbar and layout rules

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/youtube/package.json')*
- `(cd backend && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b3d3a847c83209c5faf014c64b422